### PR TITLE
Adds docker dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM  ruby:2.6.3-buster
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1 \ 
+    #
+    # Verify git and needed tools are installed
+    && apt-get install -y git procps \
+    && gem install bundler
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog
+ENV SHELL /bin/bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+    "name": "Open F# sample",
+    "dockerFile": "Dockerfile",
+    "appPort": 4000,
+    "extensions": [
+    ],
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+    "postCreateCommand": "bundle install"
+}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,4 +71,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
Creates dev container for use with VS Code

Requirements for use:

1. VS Code installed
1. [VS Code Remote Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
1. Docker for Windows/MacOS installed

Run local dev server:

After launching this repo in a container, run `bundle exec jekyll serve --baseurl "" --host 0.0.0.0`